### PR TITLE
 Add OS and architecture to binary filename in CompileBinaryCommand

### DIFF
--- a/app/Commands/CompileBinaryCommand.php
+++ b/app/Commands/CompileBinaryCommand.php
@@ -20,8 +20,9 @@ class CompileBinaryCommand extends Command
         $version = File::json(base_path('composer.json'))['version'];
 
         info("Compiling binary for version {$version}");
-
-        $destination = base_path('bin/php-parser-' . $version);
+        $osType = php_uname('s');
+        $architecture = php_uname('m');
+        $destination = base_path('bin/php-parser-' .$osType. '-' . $architecture . '-' . $version);
 
         if (File::exists($destination)) {
             if (!confirm('The binary already exists. Do you want to overwrite it?', false)) {

--- a/app/Commands/CompileBinaryCommand.php
+++ b/app/Commands/CompileBinaryCommand.php
@@ -22,6 +22,18 @@ class CompileBinaryCommand extends Command
         info("Compiling binary for version {$version}");
         $osType = strtolower(php_uname('s'));
         $architecture = php_uname('m');
+        if ($osType === 'darwin') {
+            $osType = 'mac';
+        } elseif ($osType === 'Linux') {
+            $osType = 'linux';
+        } elseif ($osType === 'Windows NT') {
+            $osType = 'windows';
+        }
+        if ($architecture === 'x86_64') {
+            $architecture = 'x64';
+        } elseif ($architecture === 'aarch64') {
+            $architecture = 'arm64';
+        }
         $destination = base_path('bin/php-parser-' .$osType. '-' . $architecture . '-' . $version);
 
         if (File::exists($destination)) {

--- a/app/Commands/CompileBinaryCommand.php
+++ b/app/Commands/CompileBinaryCommand.php
@@ -20,7 +20,7 @@ class CompileBinaryCommand extends Command
         $version = File::json(base_path('composer.json'))['version'];
 
         info("Compiling binary for version {$version}");
-        $osType = php_uname('s');
+        $osType = strtolower(php_uname('s'));
         $architecture = php_uname('m');
         $destination = base_path('bin/php-parser-' .$osType. '-' . $architecture . '-' . $version);
 

--- a/app/Commands/CompileBinaryCommand.php
+++ b/app/Commands/CompileBinaryCommand.php
@@ -20,20 +20,21 @@ class CompileBinaryCommand extends Command
         $version = File::json(base_path('composer.json'))['version'];
 
         info("Compiling binary for version {$version}");
-        $osType = strtolower(php_uname('s'));
-        $architecture = php_uname('m');
-        if ($osType === 'darwin') {
-            $osType = 'mac';
-        } elseif ($osType === 'Linux') {
-            $osType = 'linux';
-        } elseif ($osType === 'Windows NT') {
-            $osType = 'windows';
-        }
-        if ($architecture === 'x86_64') {
-            $architecture = 'x64';
-        } elseif ($architecture === 'aarch64') {
-            $architecture = 'arm64';
-        }
+        $osType = match (strtolower(php_uname('s'))) {
+            'darwin' => 'darwin',
+            'linux' => 'linux',
+            'windows nt' => 'win32',
+            default => strtolower(php_uname('s')),
+        };
+
+        $architecture = match (php_uname('m')) {
+            'x86_64', 'amd64' => 'x64',
+            'aarch64' => 'arm64',
+            'armv7l', 'armv6l' => 'arm',
+            'i386', 'i686' => 'ia32',
+            default => php_uname('m'),
+        };
+
         $destination = base_path('bin/php-parser-' .$osType. '-' . $architecture . '-' . $version);
 
         if (File::exists($destination)) {


### PR DESCRIPTION
 Updated the CompileBinaryCommand to include the operating system type and architecture in the binary filename. This change ensures that binaries
 are uniquely identified by their build environment, preventing potential conflicts when binaries for different environments are stored in the sa
 directory.