### PR TITLE
Disable logging of deprecation warnings

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -32,7 +32,7 @@ return [
     */
 
     'deprecations' => [
-        'channel' => env('LOG_DEPRECATIONS_CHANNEL', 'single'),
+        'channel' => env('LOG_DEPRECATIONS_CHANNEL', 'null'),
         'trace'   => env('LOG_DEPRECATIONS_TRACE', false),
     ],
 


### PR DESCRIPTION
Currently, the parser will log deprecation warnings in `./logs/parse.log`  as configured in `logging.php` and `AppServiceProvider.php`. This PR simply disables the logging of deprecation warnings from being logged when running the vs-code extension.

Current behavior - which I imagine is not wanted on the client machines.

```sh
globalStorage/laravel.vscode-laravel/file-downloader-downloads/php-parser-0.1.6/app/Parsers/ScopedPropertyAccessExpressionParser.php on line 19
[2024-12-16 17:58:42] production.WARNING: Creation of dynamic property App\Contexts\ArrayItem::$className is deprecated in phar:///home/user/.vscode-server/data/User/globalStorage/laravel.vscode-laravel/file-downloader-downloads/php-parser-0.1.6/app/Parsers/ScopedPropertyAccessExpressionParser.php on line 20
[2024-12-16 17:58:42] production.WARNING: Creation of dynamic property App\Contexts\ArrayItem::$methodName is deprecated in phar:///home/user/.vscode-server/data/User/globalStorage/laravel.vscode-laravel/file-downloader-downloads/php-parser-0.1.6/app/Parsers/ScopedPropertyAccessExpressionParser.php on line 19
[2024-12-16 17:58:42] production.WARNING: Creation of dynamic property App\Contexts\ArrayItem::$className is deprecated in phar:///home/user/.vscode-server/data/User/globalStorage/laravel.vscode-laravel/file-downloader-downloads/php-parser-0.1.6/app/Parsers/ScopedPropertyAccessExpressionParser.php on line 20
```
