### PR TITLE
`ScopedPropertyAccessExpressionParser` improvements

### DIFF
--- a/app/Contexts/AbstractContext.php
+++ b/app/Contexts/AbstractContext.php
@@ -117,6 +117,18 @@ abstract class AbstractContext
         return $this->parent?->searchForVar($name) ?? null;
     }
 
+    public function addPropertyToNearestClassDefinition(string $name, $types = [])
+    {
+        if ($this instanceof ClassDefinition) {
+            $this->properties[] = [
+                'name'  => $name,
+                'types' => $types,
+            ];
+        } else {
+            $this->parent?->addPropertyToNearestClassDefinition($name, $types);
+        }
+    }
+
     public function searchForProperty(string $name)
     {
         if ($this instanceof ClassDefinition) {

--- a/app/Contexts/AssignmentValue.php
+++ b/app/Contexts/AssignmentValue.php
@@ -18,13 +18,13 @@ class AssignmentValue extends AbstractContext
     {
         $child = $this->children[0] ?? null;
 
-        if ($child) {
-            return [
-                'name' => $child->name ?? $child->className ?? null,
-                'type' => $child->type(),
-            ];
+        if (!$child) {
+            return null;
         }
 
-        return null;
+        return [
+            'name' => $child->name ?? $child->className ?? null,
+            'type' => $child->type(),
+        ];
     }
 }

--- a/app/Parsers/ParameterParser.php
+++ b/app/Parsers/ParameterParser.php
@@ -19,7 +19,13 @@ class ParameterParser extends AbstractParser
     {
         $this->context->name = $node->getName();
 
+        $constructorProperty = $node->visibilityToken !== null;
+
         if (!$node->typeDeclarationList) {
+            if ($constructorProperty) {
+                $this->context->addPropertyToNearestClassDefinition($this->context->name);
+            }
+
             return $this->context->value;
         }
 
@@ -29,6 +35,10 @@ class ParameterParser extends AbstractParser
             } elseif ($type instanceof QualifiedName) {
                 $this->context->types[] = (string) $type->getResolvedName();
             }
+        }
+
+        if ($constructorProperty) {
+            $this->context->addPropertyToNearestClassDefinition($this->context->name, $this->context->types);
         }
 
         return $this->context->value;

--- a/app/Parsers/ScopedPropertyAccessExpressionParser.php
+++ b/app/Parsers/ScopedPropertyAccessExpressionParser.php
@@ -4,8 +4,11 @@ namespace App\Parsers;
 
 use App\Contexts\AbstractContext;
 use App\Contexts\Argument;
+use App\Contexts\AssignmentValue;
 use App\Contexts\MethodCall;
+use Error;
 use Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression;
+use Microsoft\PhpParser\Node\Expression\Variable;
 
 class ScopedPropertyAccessExpressionParser extends AbstractParser
 {
@@ -17,14 +20,36 @@ class ScopedPropertyAccessExpressionParser extends AbstractParser
     public function parse(ScopedPropertyAccessExpression $node)
     {
         $this->context->methodName = $node->memberName->getFullText($node->getRoot()->getFullText());
-        $this->context->className = (string) ($node->scopeResolutionQualifier?->getResolvedName() ?? $node->scopeResolutionQualifier?->getText());
+        $this->context->className = $this->resolveClassName($node);
 
         return $this->context;
     }
 
+    protected function resolveClassName(ScopedPropertyAccessExpression $node)
+    {
+        if (method_exists($node->scopeResolutionQualifier, 'getResolvedName')) {
+            return (string) $node->scopeResolutionQualifier->getResolvedName();
+        }
+
+        if ($node->scopeResolutionQualifier instanceof Variable) {
+            $result = $this->context->searchForVar($node->scopeResolutionQualifier->getName());
+
+            if ($result instanceof AssignmentValue) {
+                return $result->getValue()['name'] ?? null;
+            }
+
+            return $result;
+        }
+
+        return $node->scopeResolutionQualifier->getText();
+    }
+
     public function initNewContext(): ?AbstractContext
     {
-        if ($this->context instanceof Argument) {
+        if (
+            $this->context instanceof Argument
+            || $this->context instanceof AssignmentValue
+        ) {
             return new MethodCall;
         }
 

--- a/app/Parsers/ScopedPropertyAccessExpressionParser.php
+++ b/app/Parsers/ScopedPropertyAccessExpressionParser.php
@@ -6,7 +6,7 @@ use App\Contexts\AbstractContext;
 use App\Contexts\Argument;
 use App\Contexts\AssignmentValue;
 use App\Contexts\MethodCall;
-use Error;
+use Microsoft\PhpParser\Node\Expression\MemberAccessExpression;
 use Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression;
 use Microsoft\PhpParser\Node\Expression\Variable;
 
@@ -39,6 +39,16 @@ class ScopedPropertyAccessExpressionParser extends AbstractParser
             }
 
             return $result;
+        }
+
+        if ($node->scopeResolutionQualifier instanceof MemberAccessExpression) {
+            $parser = new MemberAccessExpressionParser;
+            $context = new MethodCall;
+            $context->parent = clone $this->context;
+            $parser->context($context);
+            $result = $parser->parseNode($node->scopeResolutionQualifier);
+
+            return $result->className ?? null;
         }
 
         return $node->scopeResolutionQualifier->getText();


### PR DESCRIPTION
Improved `ScopedPropertyAccessExpressionParser` class detection, including fixes for the following issues:

- https://github.com/laravel/vs-code-extension/issues/189 
- https://github.com/laravel/vs-code-extension/issues/177 
- https://github.com/laravel/vs-code-extension/issues/84 
- https://github.com/laravel/vs-code-extension/issues/9 
- https://github.com/laravel/vs-code-extension/issues/8