### PR TITLE
Fix Undefined property: Microsoft\PhpParser\Node\ArrayElement::$memberName

### DIFF
--- a/app/Parsers/MemberAccessExpressionParser.php
+++ b/app/Parsers/MemberAccessExpressionParser.php
@@ -30,7 +30,9 @@ class MemberAccessExpressionParser extends AbstractParser
 
             if ($child instanceof Variable) {
                 if ($child->getName() === 'this') {
-                    if ($child->getParent()->getParent() instanceof CallExpression) {
+                    $parent = $child->getParent();
+
+                    if ($parent?->getParent() instanceof CallExpression) {
                         // They are calling a method on the current class
                         $result = $this->context->nearestClassDefinition();
 
@@ -41,12 +43,14 @@ class MemberAccessExpressionParser extends AbstractParser
                         continue;
                     }
 
-                    $propName = $child->getParent()->memberName->getFullText($node->getRoot()->getFullText());
+                    if ($parent instanceof MemberAccessExpression) {
+                        $propName = $parent->memberName->getFullText($node->getRoot()->getFullText());
 
-                    $result = $this->context->searchForProperty($propName);
+                        $result = $this->context->searchForProperty($propName);
 
-                    if ($result) {
-                        $this->context->className = $result['types'][0] ?? null;
+                        if ($result) {
+                            $this->context->className = $result['types'][0] ?? null;
+                        }
                     }
 
                     continue;


### PR DESCRIPTION
Fixes https://github.com/laravel/vs-code-extension/issues/278, https://github.com/laravel/vs-code-extension/issues/363

`$child->getParent()` may return Node without $memberName property.

`$child->getParent()` may return `null`.

This PR adds an additional check and a null-safe operator.