### PR TITLE
Support for parser for blade component attributes

### DIFF
--- a/app/Parsers/InlineHtmlParser.php
+++ b/app/Parsers/InlineHtmlParser.php
@@ -124,6 +124,16 @@ class InlineHtmlParser extends AbstractParser
 
                     $range->start->character = $parameter->position->startColumn + $firstQuotePosition - $selfClosingCharacter;
                     $range->end->character = $parameter->position->startColumn + $firstQuotePosition + $rangeCharacters - $selfClosingCharacter;
+
+                    // Temporary fix for Stillat/blade-parser
+                    // If a component prefix is not x (for example flux:input instead x-flux::input)
+                    // then Stillat/blade-parser returns miscalculated positions. I don't know why
+                    if ($node->componentPrefix === "flux") {
+                        $prefixCharacters = strlen($node->componentPrefix) - 1;
+
+                        $range->start->character += $prefixCharacters + $selfClosingCharacter;
+                        $range->end->character += $prefixCharacters + $selfClosingCharacter;
+                    }
                 }
 
                 $range->start->line += $this->startLine + $parameter->position->startLine - 2;

--- a/app/Parsers/InlineHtmlParser.php
+++ b/app/Parsers/InlineHtmlParser.php
@@ -129,10 +129,8 @@ class InlineHtmlParser extends AbstractParser
                     // If a component prefix is not x (for example flux:input instead x-flux::input)
                     // then Stillat/blade-parser returns miscalculated positions. I don't know why
                     if ($node->componentPrefix === "flux") {
-                        $prefixCharacters = strlen($node->componentPrefix) - 1;
-
-                        $range->start->character += $prefixCharacters + $selfClosingCharacter;
-                        $range->end->character += $prefixCharacters + $selfClosingCharacter;
+                        $range->start->character += 3 + $selfClosingCharacter;
+                        $range->end->character += 3 + $selfClosingCharacter;
                     }
                 }
 

--- a/app/Parsers/InlineHtmlParser.php
+++ b/app/Parsers/InlineHtmlParser.php
@@ -121,7 +121,7 @@ class InlineHtmlParser extends AbstractParser
             $result = Parse::parse($sourceFile);
 
             if (count($result->children) === 0) {
-                return;
+                continue;
             }
 
             $child = $result->children[0];

--- a/app/Parsers/InlineHtmlParser.php
+++ b/app/Parsers/InlineHtmlParser.php
@@ -50,7 +50,7 @@ class InlineHtmlParser extends AbstractParser
             $this->startLine = $range->start->line;
         }
 
-        $this->parseBladeContent(Document::fromText($node->getText()));
+        $this->parseBladeContent(Document::fromText($node->getText(), customComponentTags: ['flux']));
 
         if (count($this->items)) {
             $blade = new Blade;


### PR DESCRIPTION
This PR adds support for parser for blade component attributes. Every attribute with a function supported by the extension has a link to the target file.

Before:

![before](https://github.com/user-attachments/assets/9f957e6e-41e3-405c-a1a9-97339015808f)

After:

![after](https://github.com/user-attachments/assets/18a60159-0df3-4f90-9bf7-ad68a2222888)

Works with and without blade prefix/suffix statements.

~~Unfortunately, the value is not shown in the hover. It is related to this code snippet > https://github.com/laravel/vs-code-extension/blob/main/src/support/parser.ts#L312-L316~~

~~Blade component attributes have differently calculated hover positions. I don't know how to fix this :/~~

I found a solution > https://github.com/laravel/vs-code-extension/pull/344