### PR TITLE
Add VariableParser and VariableContext

### DIFF
--- a/app/Contexts/Variable.php
+++ b/app/Contexts/Variable.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Contexts;
+
+class Variable extends AbstractContext
+{
+    public ?string $name = null;
+
+    protected bool $hasChildren = false;
+
+    public function type(): string
+    {
+        return 'variable';
+    }
+
+    public function castToArray(): array
+    {
+        return [
+            'name' => $this->name,
+        ];
+    }
+}

--- a/app/Contexts/Variable.php
+++ b/app/Contexts/Variable.php
@@ -4,7 +4,7 @@ namespace App\Contexts;
 
 class Variable extends AbstractContext
 {
-    public ?string $varName = null;
+    public ?string $name = null;
 
     public ?string $className = null;
 
@@ -18,7 +18,7 @@ class Variable extends AbstractContext
     public function castToArray(): array
     {
         return [
-            'varName' => $this->varName,
+            'name' => $this->name,
             'className' => $this->className,
         ];
     }

--- a/app/Contexts/Variable.php
+++ b/app/Contexts/Variable.php
@@ -18,7 +18,7 @@ class Variable extends AbstractContext
     public function castToArray(): array
     {
         return [
-            'name' => $this->varName,
+            'varName' => $this->varName,
             'className' => $this->className,
         ];
     }

--- a/app/Contexts/Variable.php
+++ b/app/Contexts/Variable.php
@@ -4,7 +4,9 @@ namespace App\Contexts;
 
 class Variable extends AbstractContext
 {
-    public ?string $name = null;
+    public ?string $varName = null;
+
+    public ?string $className = null;
 
     protected bool $hasChildren = false;
 
@@ -16,7 +18,8 @@ class Variable extends AbstractContext
     public function castToArray(): array
     {
         return [
-            'name' => $this->name,
+            'name' => $this->varName,
+            'className' => $this->className,
         ];
     }
 }

--- a/app/Parsers/MethodDeclarationParser.php
+++ b/app/Parsers/MethodDeclarationParser.php
@@ -20,7 +20,7 @@ class MethodDeclarationParser extends AbstractParser
         // Every method is a new context, so we need to clear
         // the previous variable contexts
         // @see https://github.com/laravel/vs-code-php-parser-cli/pull/14
-        VariableParser::$previousContexts = collect();
+        VariableParser::$previousContexts = [];
 
         return $this->context;
     }

--- a/app/Parsers/MethodDeclarationParser.php
+++ b/app/Parsers/MethodDeclarationParser.php
@@ -17,6 +17,11 @@ class MethodDeclarationParser extends AbstractParser
     {
         $this->context->methodName = $node->getName();
 
+        // Every method is a new context, so we need to clear
+        // the previous variable contexts
+        // @see https://github.com/laravel/vs-code-php-parser-cli/pull/14
+        VariableParser::$previousContexts = [];
+
         return $this->context;
     }
 

--- a/app/Parsers/MethodDeclarationParser.php
+++ b/app/Parsers/MethodDeclarationParser.php
@@ -20,7 +20,7 @@ class MethodDeclarationParser extends AbstractParser
         // Every method is a new context, so we need to clear
         // the previous variable contexts
         // @see https://github.com/laravel/vs-code-php-parser-cli/pull/14
-        VariableParser::$previousContexts = [];
+        VariableParser::$previousContexts = collect();
 
         return $this->context;
     }

--- a/app/Parsers/VariableParser.php
+++ b/app/Parsers/VariableParser.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Parsers;
+
+use App\Contexts\AbstractContext;
+use App\Contexts\Variable as VariableContext;
+use App\Parser\Settings;
+use Microsoft\PhpParser\Node\Expression\Variable;
+use Microsoft\PhpParser\PositionUtilities;
+
+class VariableParser extends AbstractParser
+{
+    /**
+     * @var VariableContext
+     */
+    protected AbstractContext $context;
+
+    public function parse(Variable $node)
+    {
+        $this->context->name = $node->getName();
+
+        if (Settings::$capturePosition) {
+            $range = PositionUtilities::getRangeFromPosition(
+                $node->getStartPosition(),
+                mb_strlen($node->getText()),
+                $node->getRoot()->getFullText(),
+            );
+
+            if (Settings::$calculatePosition !== null) {
+                $range = Settings::adjustPosition($range);
+            }
+
+            $this->context->setPosition($range);
+        }
+
+        return $this->context;
+    }
+
+    public function initNewContext(): ?AbstractContext
+    {
+        return new VariableContext;
+    }
+}

--- a/app/Parsers/VariableParser.php
+++ b/app/Parsers/VariableParser.php
@@ -18,9 +18,9 @@ class VariableParser extends AbstractParser
 
     public function parse(Variable $node)
     {
-        $this->context->name = $node->getName();
+        $this->context->varName = $node->getName();
 
-        $result = $this->context->searchForVar($this->context->name);
+        $result = $this->context->searchForVar($this->context->varName);
 
         if (is_string($result)) {
             $this->context->className = $result;

--- a/app/Parsers/VariableParser.php
+++ b/app/Parsers/VariableParser.php
@@ -6,6 +6,7 @@ use App\Contexts\AbstractContext;
 use App\Contexts\Variable as VariableContext;
 use App\Parser\Settings;
 use Microsoft\PhpParser\Node\Expression\Variable;
+use Microsoft\PhpParser\Node\Statement\ExpressionStatement;
 use Microsoft\PhpParser\PositionUtilities;
 
 class VariableParser extends AbstractParser
@@ -18,6 +19,12 @@ class VariableParser extends AbstractParser
     public function parse(Variable $node)
     {
         $this->context->name = $node->getName();
+
+        $result = $this->context->searchForVar($this->context->name);
+
+        if (is_string($result)) {
+            $this->context->className = $result;
+        }
 
         if (Settings::$capturePosition) {
             $range = PositionUtilities::getRangeFromPosition(

--- a/app/Parsers/VariableParser.php
+++ b/app/Parsers/VariableParser.php
@@ -6,7 +6,6 @@ use App\Contexts\AbstractContext;
 use App\Contexts\Variable as VariableContext;
 use App\Parser\Settings;
 use Microsoft\PhpParser\Node\Expression\Variable;
-use Microsoft\PhpParser\Node\Statement\ExpressionStatement;
 use Microsoft\PhpParser\PositionUtilities;
 
 class VariableParser extends AbstractParser
@@ -18,9 +17,9 @@ class VariableParser extends AbstractParser
 
     public function parse(Variable $node)
     {
-        $this->context->varName = $node->getName();
+        $this->context->name = $node->getName();
 
-        $result = $this->context->searchForVar($this->context->varName);
+        $result = $this->context->searchForVar($this->context->name);
 
         if (is_string($result)) {
             $this->context->className = $result;

--- a/app/Parsers/VariableParser.php
+++ b/app/Parsers/VariableParser.php
@@ -5,8 +5,19 @@ namespace App\Parsers;
 use App\Contexts\AbstractContext;
 use App\Contexts\Variable as VariableContext;
 use App\Parser\Settings;
+use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\Variable;
+use Microsoft\PhpParser\Node\NamespaceUseClause;
+use Microsoft\PhpParser\Node\Statement\NamespaceUseDeclaration;
 use Microsoft\PhpParser\PositionUtilities;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\ConstExprParser;
+use PHPStan\PhpDocParser\Parser\PhpDocParser;
+use PHPStan\PhpDocParser\Parser\TokenIterator;
+use PHPStan\PhpDocParser\Parser\TypeParser;
+use PHPStan\PhpDocParser\ParserConfig;
 
 class VariableParser extends AbstractParser
 {
@@ -15,14 +26,109 @@ class VariableParser extends AbstractParser
      */
     protected AbstractContext $context;
 
+    public static array $previousContexts = [];
+
+    private function getLatestDocComment(Node $node): ?string
+    {
+        $docComment = $node->getDocCommentText();
+
+        if ($docComment === null && $node->getParent() !== null) {
+            return $this->getLatestDocComment($node->getParent());
+        }
+
+        return $docComment;
+    }
+
     public function parse(Variable $node)
     {
         $this->context->name = $node->getName();
 
         $result = $this->context->searchForVar($this->context->name);
 
+        // Firstly, we try to find the className from the method parameter
         if (is_string($result)) {
             $this->context->className = $result;
+        }
+
+        // If the className is still not found, we try to find the className
+        // from the doc comment, for example:
+        //
+        // /** @var User $user */
+        // Gate::allows('edit', $user);
+        if ($this->context->className === null) {
+            $docComment = $this->getLatestDocComment($node);
+
+            if ($docComment !== null) {
+                $config = new ParserConfig([]);
+                $lexer = new Lexer($config);
+                $constExprParser = new ConstExprParser($config);
+                $typeParser = new TypeParser($config, $constExprParser);
+                $phpDocParser = new PhpDocParser($config, $typeParser, $constExprParser);
+
+                $tokens = new TokenIterator($lexer->tokenize($docComment));
+                $phpDocNode = $phpDocParser->parse($tokens);
+                $varTagValues = $phpDocNode->getVarTagValues();
+
+                /** @var VarTagValueNode|null $tagValue */
+                $tagValue = collect($varTagValues)
+                    // We need to remove first character because it's always $
+                    ->first(fn(VarTagValueNode $valueNode) => substr($valueNode->variableName, 1) === $this->context->name);
+
+                if ($tagValue?->type instanceof IdentifierTypeNode) {
+                    // If the class name starts with a backslash, it's a fully qualified name
+                    if (str_starts_with($tagValue->type->name, '\\')) {
+                        $this->context->className = substr($tagValue->type->name, 1);
+                    // Otherwise, it's a short name and we need to find the fully qualified name from
+                    // the imported namespaces
+                    } else {
+                        $uses = [];
+
+                        foreach ($node->getRoot()->getDescendantNodes() as $node) {
+                            if (! $node instanceof NamespaceUseDeclaration) {
+                                continue;
+                            }
+
+                            foreach ($node->useClauses->children ?? [] as $clause) {
+                                if (! $clause instanceof NamespaceUseClause) {
+                                    continue;
+                                }
+
+                                $fqcn = $clause->namespaceName->getText();
+
+                                // If the namespace has an alias, we need to use the alias as the short name
+                                $alias = $clause->namespaceAliasingClause
+                                    ? str($clause->namespaceAliasingClause->getText())
+                                        ->after('as')
+                                        ->trim()
+                                        ->toString()
+                                    : str($fqcn)->explode('\\')->last();
+
+                                // Finally, we add the short and fully qualified name to the uses array
+                                $uses[$alias] = $fqcn;
+                            }
+                        }
+
+                        $this->context->className = $uses[$tagValue->type->name] ?? null;
+                    }
+                }
+            }
+        }
+
+        // If the className is still not found, we try to find the className
+        // from the previous variable contexts, for example:
+        //
+        // /** @var \App\Models\User $user */
+        // $user = $request->user;
+        //
+        // Gate::allows('edit', $user);
+        if ($this->context->className === null) {
+            /** @var VariableContext|null $previousVariableContext */
+            $previousVariableContext = collect(self::$previousContexts)
+                ->first(fn(VariableContext $context) => $context->name === $this->context->name);
+
+            if ($previousVariableContext !== null) {
+                $this->context->className = $previousVariableContext->className;
+            }
         }
 
         if (Settings::$capturePosition) {
@@ -38,6 +144,8 @@ class VariableParser extends AbstractParser
 
             $this->context->setPosition($range);
         }
+
+        array_push(self::$previousContexts, $this->context);
 
         return $this->context;
     }

--- a/app/Parsers/VariableParser.php
+++ b/app/Parsers/VariableParser.php
@@ -5,7 +5,6 @@ namespace App\Parsers;
 use App\Contexts\AbstractContext;
 use App\Contexts\Variable as VariableContext;
 use App\Parser\Settings;
-use Illuminate\Support\Collection;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\Variable;
 use Microsoft\PhpParser\Node\NamespaceUseClause;
@@ -27,7 +26,7 @@ class VariableParser extends AbstractParser
      */
     protected AbstractContext $context;
 
-    public static Collection $previousContexts;
+    public static array $previousContexts = [];
 
     private function createPhpDocParser(ParserConfig $config): PhpDocParser
     {
@@ -114,12 +113,8 @@ class VariableParser extends AbstractParser
 
     private function searchPreviousContexts(): ?string
     {
-        if (! self::$previousContexts instanceof Collection) {
-            self::$previousContexts = collect();
-        }
-
         /** @var VariableContext|null $previousVariableContext */
-        $previousVariableContext = self::$previousContexts
+        $previousVariableContext = collect(self::$previousContexts)
             ->last(fn (VariableContext $context) => $context->name === $this->context->name);
 
         return $previousVariableContext?->className;
@@ -168,7 +163,7 @@ class VariableParser extends AbstractParser
             $this->context->setPosition($range);
         }
 
-        self::$previousContexts->push($this->context);
+        array_push(self::$previousContexts, $this->context);
 
         return $this->context;
     }

--- a/app/Parsers/VariableParser.php
+++ b/app/Parsers/VariableParser.php
@@ -65,18 +65,18 @@ class VariableParser extends AbstractParser
 
         $varTagValues = $phpDocNode->getVarTagValues();
 
-        /** @var VarTagValueNode|null $tagValue */
-        $tagValue = collect($varTagValues)
+        /** @var VarTagValueNode|null $varTagValue */
+        $varTagValue = collect($varTagValues)
             // We need to remove first character because it's always $
             ->first(fn (VarTagValueNode $valueNode) => substr($valueNode->variableName, 1) === $this->context->name);
 
-        if (! $tagValue?->type instanceof IdentifierTypeNode) {
+        if (! $varTagValue?->type instanceof IdentifierTypeNode) {
             return null;
         }
 
         // If the class name starts with a backslash, it's a fully qualified name
-        if (str_starts_with($tagValue->type->name, '\\')) {
-            return substr($tagValue->type->name, 1);
+        if (str_starts_with($varTagValue->type->name, '\\')) {
+            return substr($varTagValue->type->name, 1);
         }
 
         // Otherwise, it's a short name and we need to find the fully qualified name from
@@ -108,7 +108,7 @@ class VariableParser extends AbstractParser
             }
         }
 
-        return $uses[$tagValue->type->name] ?? null;
+        return $uses[$varTagValue->type->name] ?? null;
     }
 
     private function searchPreviousContexts(): ?string

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "illuminate/log": "^11.5",
         "laravel-zero/framework": "^11.0.0",
         "microsoft/tolerant-php-parser": "^0.1.2",
+        "phpstan/phpdoc-parser": "^2.3",
         "stillat/blade-parser": "^1.10"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f17bbd5e400471f42d8477b9c18eb8d3",
+    "content-hash": "26e8b6111294cc63899dee62d8623a9d",
     "packages": [
         {
             "name": "brick/math",
@@ -3153,6 +3153,53 @@
                 }
             ],
             "time": "2024-07-20T21:41:07+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/1e0cd5370df5dd2e556a36b9c62f62e555870495",
+                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.0"
+            },
+            "time": "2025-08-30T15:50:23+00:00"
         },
         {
             "name": "psr/clock",
@@ -7464,53 +7511,6 @@
                 "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.10.0"
             },
             "time": "2024-11-09T15:12:26+00:00"
-        },
-        {
-            "name": "phpstan/phpdoc-parser",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "c00d78fb6b29658347f9d37ebe104bffadf36299"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/c00d78fb6b29658347f9d37ebe104bffadf36299",
-                "reference": "c00d78fb6b29658347f9d37ebe104bffadf36299",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/annotations": "^2.0",
-                "nikic/php-parser": "^5.3.0",
-                "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^2.0",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^9.6",
-                "symfony/process": "^5.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PHPStan\\PhpDocParser\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHPDoc parser with support for nullable, intersection and generic types",
-            "support": {
-                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.0.0"
-            },
-            "time": "2024-10-13T11:29:49+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
This PR adds support for VariableParser and VariableContext.

For example, currently, this command:

```
php-parser detect "<?php

/** @var \\App\\Models\\User \$user */
Gate::authorize('edit', \$user);" --debug
```

returns:

```
================================================================================
================================================================================
                              STARTING TO PARSE
================================================================================
================================================================================

Microsoft\PhpParser\Node\SourceFileNode <?php Gate::authorize('edit', $user);
+ Context: App\Contexts\Base
* Parsing: App\Parsers\SourceFileNodeParser

 Microsoft\PhpParser\Node\Statement\InlineHtml <?php 
 + Context: App\Contexts\Base
 * Parsing: App\Parsers\InlineHtmlParser

 Microsoft\PhpParser\Node\Statement\ExpressionStatement Gate::authorize('edit', $user);
 + Context: App\Contexts\Base
 * Parsing: App\Parsers\ExpressionStatementParser

  Microsoft\PhpParser\Node\Expression\CallExpression Gate::authorize('edit', $user)
  + Context: App\Contexts\MethodCall
  * Parsing: App\Parsers\CallExpressionParser

   Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression Gate::authorize
   + Context: App\Contexts\MethodCall
   * Parsing: App\Parsers\ScopedPropertyAccessExpressionParser

    Microsoft\PhpParser\Node\QualifiedName Gate
   Microsoft\PhpParser\Node\DelimitedList\ArgumentExpressionList 'edit', $user
   + Context: App\Contexts\MethodCall
   * Parsing: App\Parsers\ArgumentExpressionListParser

    Microsoft\PhpParser\Node\Expression\ArgumentExpression 'edit'
    + Context: App\Contexts\Argument
    * Parsing: App\Parsers\ArgumentExpressionParser

     Microsoft\PhpParser\Node\StringLiteral 'edit'
     + Context: App\Contexts\StringValue
     * Parsing: App\Parsers\StringLiteralParser

    Microsoft\PhpParser\Node\Expression\ArgumentExpression $user
    + Context: App\Contexts\Argument
    * Parsing: App\Parsers\ArgumentExpressionParser

     Microsoft\PhpParser\Node\Expression\Variable $user
[
    {
        "type": "methodCall",
        "methodName": "authorize",
        "className": "Gate",
        "arguments": {
            "type": "arguments",
            "autocompletingIndex": 2,
            "children": [
                {
                    "type": "argument",
                    "name": null,
                    "children": [
                        {
                            "type": "string",
                            "value": "edit",
                            "start": {
                                "line": 2,
                                "column": 16
                            },
                            "end": {
                                "line": 2,
                                "column": 20
                            }
                        }
                    ]
                },
                {
                    "type": "argument",
                    "name": null,
                    "children": []
                }
            ]
        }
    }
]
```

With VariableParser and VariableContext:

```
================================================================================
================================================================================
                              STARTING TO PARSE
================================================================================
================================================================================

Microsoft\PhpParser\Node\SourceFileNode <?php /** @var \App\Models\User $user */ Gate::aut
+ Context: App\Contexts\Base
* Parsing: App\Parsers\SourceFileNodeParser

 Microsoft\PhpParser\Node\Statement\InlineHtml <?php 
 + Context: App\Contexts\Base
 * Parsing: App\Parsers\InlineHtmlParser

 Microsoft\PhpParser\Node\Statement\ExpressionStatement Gate::authorize('edit', $user);
 + Context: App\Contexts\Base
 * Parsing: App\Parsers\ExpressionStatementParser

  Microsoft\PhpParser\Node\Expression\CallExpression Gate::authorize('edit', $user)
  + Context: App\Contexts\MethodCall
  * Parsing: App\Parsers\CallExpressionParser

   Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression Gate::authorize
   + Context: App\Contexts\MethodCall
   * Parsing: App\Parsers\ScopedPropertyAccessExpressionParser

    Microsoft\PhpParser\Node\QualifiedName Gate
   Microsoft\PhpParser\Node\DelimitedList\ArgumentExpressionList 'edit', $user
   + Context: App\Contexts\MethodCall
   * Parsing: App\Parsers\ArgumentExpressionListParser

    Microsoft\PhpParser\Node\Expression\ArgumentExpression 'edit'
    + Context: App\Contexts\Argument
    * Parsing: App\Parsers\ArgumentExpressionParser

     Microsoft\PhpParser\Node\StringLiteral 'edit'
     + Context: App\Contexts\StringValue
     * Parsing: App\Parsers\StringLiteralParser

    Microsoft\PhpParser\Node\Expression\ArgumentExpression $user
    + Context: App\Contexts\Argument
    * Parsing: App\Parsers\ArgumentExpressionParser

     Microsoft\PhpParser\Node\Expression\Variable $user
     + Context: App\Contexts\Variable
     * Parsing: App\Parsers\VariableParser

[
    {
        "type": "methodCall",
        "methodName": "authorize",
        "className": "Gate",
        "arguments": {
            "type": "arguments",
            "autocompletingIndex": 2,
            "children": [
                {
                    "type": "argument",
                    "name": null,
                    "children": [
                        {
                            "type": "string",
                            "value": "edit",
                            "start": {
                                "line": 3,
                                "column": 16
                            },
                            "end": {
                                "line": 3,
                                "column": 20
                            }
                        }
                    ]
                },
                {
                    "type": "argument",
                    "name": null,
                    "children": [
                        {
                            "type": "variable",
                            "name": "user",
                            "className": "App\\Models\\User",
                            "start": {
                                "line": 3,
                                "column": 24
                            },
                            "end": {
                                "line": 3,
                                "column": 29
                            }
                        }
                    ]
                }
            ]
        }
    }
]
```