### PR TITLE
Fix Double quotes does not trigger the autocomplete

### DIFF
--- a/app/Parser/Walker.php
+++ b/app/Parser/Walker.php
@@ -26,8 +26,8 @@ class Walker
     public function __construct(protected string $document, $debug = false)
     {
         $this->debug = $debug;
-        $this->document = $document;
-        $this->sourceFile = (new Parser)->parseSourceFile(trim($this->document));
+        $this->document = trim($document);
+        $this->sourceFile = (new Parser)->parseSourceFile($this->document);
         $this->context = new Context;
     }
 
@@ -45,10 +45,10 @@ class Walker
      *
      * This function parse source file again if last character is a double quote.
      */
-    private function setSourceFileAgainIfLastCharacterIsDoubleQuote(string $text): void
+    private function parseSourceFileAgainIfLastCharacterIsDoubleQuote(): void
     {
-        if (substr($text, -1) === '"') {
-            $this->sourceFile = (new Parser)->parseSourceFile(trim(substr($text, 0, -1) . "'"));
+        if (substr($this->document, -1) === '"') {
+            $this->sourceFile = (new Parser)->parseSourceFile(substr($this->document, 0, -1) . "'");
         }
     }
 
@@ -77,7 +77,7 @@ class Walker
             return new Base;
         }
 
-        $this->setSourceFileAgainIfLastCharacterIsDoubleQuote($this->document);
+        $this->parseSourceFileAgainIfLastCharacterIsDoubleQuote();
 
         Parse::$debug = $this->debug;
 

--- a/app/Parser/Walker.php
+++ b/app/Parser/Walker.php
@@ -67,7 +67,7 @@ class Walker
      *
      * and returns ";" as an argument.
      *
-     * This function replaces the last double quote with a single quote.
+     * This function replaces the last double quote with a single quote in document.
      */
     private function replaceLastDoubleQuoteWithSingleQuote(): string
     {

--- a/app/Parser/Walker.php
+++ b/app/Parser/Walker.php
@@ -26,9 +26,7 @@ class Walker
     public function __construct(protected string $document, $debug = false)
     {
         $this->debug = $debug;
-        $this->sourceFile = (new Parser)->parseSourceFile(
-            $this->replaceLastDoubleQuoteToSingleQuote(trim($this->document))
-        );
+        $this->sourceFile = (new Parser)->parseSourceFile(trim($this->document));
         $this->context = new Context;
     }
 
@@ -49,25 +47,6 @@ class Walker
         }
 
         return false;
-    }
-
-    /**
-     * If a last character is a double quote, for example:
-     *
-     * {{ config("
-     *
-     * then Microsoft\PhpParser\Parser::parseSourceFile returns autocompletingIndex: 1
-     * instead 0. Probably the parser turns the string into something like this:
-     *
-     * "{{ config(";"
-     *
-     * and returns ";" as an argument.
-     *
-     * This function replaces the last double quote with a single quote.
-     */
-    private function replaceLastDoubleQuoteToSingleQuote(string $text)
-    {
-        return substr($text, -1) === '"' ? substr($text, 0, -1) . "'" : $text;
     }
 
     public function walk()

--- a/app/Parser/Walker.php
+++ b/app/Parser/Walker.php
@@ -26,7 +26,9 @@ class Walker
     public function __construct(protected string $document, $debug = false)
     {
         $this->debug = $debug;
-        $this->sourceFile = (new Parser)->parseSourceFile(trim($this->document));
+        $this->sourceFile = (new Parser)->parseSourceFile(
+            $this->replaceLastDoubleQuoteToSingleQuote(trim($this->document))
+        );
         $this->context = new Context;
     }
 
@@ -47,6 +49,25 @@ class Walker
         }
 
         return false;
+    }
+
+    /**
+     * If a last character is a double quote, for example:
+     *
+     * {{ config("
+     *
+     * then Microsoft\PhpParser\Parser::parseSourceFile returns autocompletingIndex: 1
+     * instead 0. Probably the parser turns the string into something like this:
+     *
+     * "{{ config(";"
+     *
+     * and returns ";" as an argument.
+     *
+     * This function replaces the last double quote with a single quote.
+     */
+    private function replaceLastDoubleQuoteToSingleQuote(string $text)
+    {
+        return substr($text, -1) === '"' ? substr($text, 0, -1) . "'" : $text;
     }
 
     public function walk()

--- a/app/Parser/Walker.php
+++ b/app/Parser/Walker.php
@@ -55,20 +55,6 @@ class Walker
         return substr($this->document, -1) === '"';
     }
 
-    /**
-     * If a last character is a double quote, for example:
-     *
-     * {{ config("
-     *
-     * then Microsoft\PhpParser\Parser::parseSourceFile returns autocompletingIndex: 1
-     * instead 0. Probably the parser turns the string into something like this:
-     *
-     * "{{ config(";"
-     *
-     * and returns ";" as an argument.
-     *
-     * This function replaces the last double quote with a single quote in document.
-     */
     private function replaceLastDoubleQuoteWithSingleQuote(): string
     {
         return substr($this->document, 0, -1) . "'";
@@ -80,6 +66,20 @@ class Walker
             return new Base;
         }
 
+        /**
+         * If a last character is a double quote, for example:
+         *
+         * {{ config("
+         *
+         * then Microsoft\PhpParser\Parser::parseSourceFile returns autocompletingIndex: 1
+         * instead 0. Probably the parser turns the string into something like this:
+         *
+         * "{{ config(";"
+         *
+         * and returns ";" as an argument.
+         *
+         * This line of code checks if the last character is a double quote and fixes it.
+         */
         if ($this->documentHasDoubleQuoteAsLastCharacter()) {
             return (new self($this->replaceLastDoubleQuoteWithSingleQuote(), $this->debug))->walk();
         }

--- a/app/Parsers/InlineHtmlParser.php
+++ b/app/Parsers/InlineHtmlParser.php
@@ -46,7 +46,9 @@ class InlineHtmlParser extends AbstractParser
             $this->startLine = $range->start->line;
         }
 
-        $this->parseBladeContent(Document::fromText($node->getText()));
+        $this->parseBladeContent(Document::fromText(
+            $this->replaceLastDoubleQuoteToSingleQuote($node->getText()),
+        ));
 
         if (count($this->items)) {
             $blade = new Blade;
@@ -58,6 +60,34 @@ class InlineHtmlParser extends AbstractParser
         }
 
         return $this->context;
+    }
+
+    /**
+     * If a last character is a double quote, for example:
+     *
+     * {{ config("
+     *
+     * then Stillat\BladeParser\Document\Document::fromText returns autocompletingIndex: 1
+     * instead 0. Probably the parser turns the string into something like this:
+     *
+     * "{{ config(";"
+     *
+     * and returns ";" as an argument.
+     *
+     * This function replaces the last double quote with a single quote.
+     */
+    private function replaceLastDoubleQuoteToSingleQuote(string $text): string
+    {
+        if (substr($text, -1) === '"') {
+            $countDoubleQuotes = substr_count($text, '"');
+
+            // We have to exclude cases with an even number of double quotes
+            if ($countDoubleQuotes % 2 !== 0) {
+                return substr($text, 0, -1) . "'";
+            }
+        }
+
+        return $text;
     }
 
     protected function parseBladeContent($node)
@@ -95,7 +125,7 @@ class InlineHtmlParser extends AbstractParser
             }
 
             $range->start->line += $this->startLine + $node->position->startLine - 2;
-            $range->end->line += $this->startLine +  $node->position->startLine - 2;
+            $range->end->line += $this->startLine + $node->position->startLine - 2;
 
             return $range;
         };

--- a/app/Parsers/InlineHtmlParser.php
+++ b/app/Parsers/InlineHtmlParser.php
@@ -46,9 +46,7 @@ class InlineHtmlParser extends AbstractParser
             $this->startLine = $range->start->line;
         }
 
-        $this->parseBladeContent(Document::fromText(
-            $this->replaceLastDoubleQuoteToSingleQuote($node->getText()),
-        ));
+        $this->parseBladeContent(Document::fromText($node->getText()));
 
         if (count($this->items)) {
             $blade = new Blade;
@@ -60,34 +58,6 @@ class InlineHtmlParser extends AbstractParser
         }
 
         return $this->context;
-    }
-
-    /**
-     * If a last character is a double quote, for example:
-     *
-     * {{ config("
-     *
-     * then Stillat\BladeParser\Document\Document::fromText returns autocompletingIndex: 1
-     * instead 0. Probably the parser turns the string into something like this:
-     *
-     * "{{ config(";"
-     *
-     * and returns ";" as an argument.
-     *
-     * This function replaces the last double quote with a single quote.
-     */
-    private function replaceLastDoubleQuoteToSingleQuote(string $text): string
-    {
-        if (substr($text, -1) === '"') {
-            $countDoubleQuotes = substr_count($text, '"');
-
-            // We have to exclude cases with an even number of double quotes
-            if ($countDoubleQuotes % 2 !== 0) {
-                return substr($text, 0, -1) . "'";
-            }
-        }
-
-        return $text;
     }
 
     protected function parseBladeContent($node)


### PR DESCRIPTION
Fixes https://github.com/laravel/vs-code-extension/issues/339

If a last character is a double quote, for example:

```php
{{ config("
```
then Microsoft\PhpParser\Parser::parseSourceFile returns autocompletingIndex: 1 instead 0. Example:

```
php-parser autocomplete "{{ config(\"" --debug
```

returns:

```
================================================================================
================================================================================
                              STARTING TO PARSE
================================================================================
================================================================================

Microsoft\PhpParser\Node\SourceFileNode {{ config("
+ Context: App\Contexts\Base
* Parsing: App\Parsers\SourceFileNodeParser

 Microsoft\PhpParser\Node\Statement\InlineHtml {{ config("
 + Context: App\Contexts\Base
 * Parsing: App\Parsers\InlineHtmlParser


================================================================================
================================================================================
                              STARTING TO PARSE
================================================================================
================================================================================

Microsoft\PhpParser\Node\SourceFileNode <?php config(";
+ Context: App\Contexts\Base
* Parsing: App\Parsers\SourceFileNodeParser

 Microsoft\PhpParser\Node\Statement\InlineHtml <?php 
 + Context: App\Contexts\Base
 * Parsing: App\Parsers\InlineHtmlParser

 Microsoft\PhpParser\Node\Statement\ExpressionStatement config(";
 + Context: App\Contexts\Base
 * Parsing: App\Parsers\ExpressionStatementParser

  Microsoft\PhpParser\Node\Expression\CallExpression config(";
  + Context: App\Contexts\MethodCall
  * Parsing: App\Parsers\CallExpressionParser

   Microsoft\PhpParser\Node\QualifiedName config
   Microsoft\PhpParser\Node\DelimitedList\ArgumentExpressionList ";
   + Context: App\Contexts\MethodCall
   * Parsing: App\Parsers\ArgumentExpressionListParser

    Microsoft\PhpParser\Node\Expression\ArgumentExpression ";
    + Context: App\Contexts\Argument
    * Parsing: App\Parsers\ArgumentExpressionParser

     Microsoft\PhpParser\Node\StringLiteral ";
     + Context: App\Contexts\StringValue
     * Parsing: App\Parsers\StringLiteralParser

{
    "type": "methodCall",
    "autocompleting": true,
    "methodName": "config",
    "className": null,
    "arguments": {
        "type": "arguments",
        "autocompletingIndex": 1,
        "children": [
            {
                "type": "argument",
                "name": null,
                "children": [
                    {
                        "type": "string",
                        "value": ";"
                    }
                ]
            }
        ]
    },
    "parent": {
        "type": "base",
        "parent": null
    }
}
```
Comparison with a "single quote" example:

```
php-parser autocomplete "{{ config('" --debug
```

returns:

```
================================================================================
================================================================================
                              STARTING TO PARSE
================================================================================
================================================================================

Microsoft\PhpParser\Node\SourceFileNode {{ config('
+ Context: App\Contexts\Base
* Parsing: App\Parsers\SourceFileNodeParser

 Microsoft\PhpParser\Node\Statement\InlineHtml {{ config('
 + Context: App\Contexts\Base
 * Parsing: App\Parsers\InlineHtmlParser


================================================================================
================================================================================
                              STARTING TO PARSE
================================================================================
================================================================================

Microsoft\PhpParser\Node\SourceFileNode <?php config(';
+ Context: App\Contexts\Base
* Parsing: App\Parsers\SourceFileNodeParser

 Microsoft\PhpParser\Node\Statement\InlineHtml <?php 
 + Context: App\Contexts\Base
 * Parsing: App\Parsers\InlineHtmlParser

 Microsoft\PhpParser\Node\Statement\ExpressionStatement config(
 + Context: App\Contexts\Base
 * Parsing: App\Parsers\ExpressionStatementParser

  Microsoft\PhpParser\Node\Expression\CallExpression config(
  + Context: App\Contexts\MethodCall
  * Parsing: App\Parsers\CallExpressionParser

   Microsoft\PhpParser\Node\QualifiedName config
{
    "type": "methodCall",
    "autocompleting": true,
    "methodName": "config",
    "className": null,
    "arguments": {
        "type": "arguments",
        "autocompletingIndex": 0,
        "children": []
    },
    "parent": {
        "type": "base",
        "parent": null
    }
}
```

Probably the parser turns the string into something like this:

```php
"{{ config(";"
```
and returns `";"` as an argument.

This PR adds an extra check that the last character is a double quote. If so, replace it with a single quote.