### PR TITLE
Support for PHP attributes

### DIFF
--- a/app/Parser/DetectWalker.php
+++ b/app/Parser/DetectWalker.php
@@ -7,6 +7,7 @@ use App\Contexts\Blade;
 use App\Support\Debugs;
 use Illuminate\Support\Arr;
 use Microsoft\PhpParser\Node;
+use Microsoft\PhpParser\Node\Attribute;
 use Microsoft\PhpParser\Node\Expression\CallExpression;
 use Microsoft\PhpParser\Node\Expression\ObjectCreationExpression;
 use Microsoft\PhpParser\Node\SourceFileNode;
@@ -52,6 +53,7 @@ class DetectWalker
     protected function handleContext(Node $node, AbstractContext $context)
     {
         $nodesToDetect = [
+            Attribute::class,
             CallExpression::class,
             ObjectCreationExpression::class,
         ];

--- a/app/Parsers/ArgumentExpressionListParser.php
+++ b/app/Parsers/ArgumentExpressionListParser.php
@@ -4,6 +4,7 @@ namespace App\Parsers;
 
 use App\Contexts\AbstractContext;
 use App\Contexts\MethodCall;
+use App\Contexts\ObjectValue;
 
 class ArgumentExpressionListParser extends AbstractParser
 {
@@ -14,7 +15,7 @@ class ArgumentExpressionListParser extends AbstractParser
 
     public function parse($node)
     {
-        if ($this->context instanceof MethodCall) {
+        if ($this->context instanceof MethodCall || $this->context instanceof ObjectValue) {
             return $this->context->arguments;
         }
 

--- a/app/Parsers/AttributeParser.php
+++ b/app/Parsers/AttributeParser.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Parsers;
+
+use App\Contexts\AbstractContext;
+use App\Contexts\ObjectValue;
+use Microsoft\PhpParser\MissingToken;
+use Microsoft\PhpParser\Node\Attribute as AttributeNode;
+use Microsoft\PhpParser\Node\QualifiedName;
+
+class AttributeParser extends AbstractParser
+{
+    /**
+     * @var ObjectValue
+     */
+    protected AbstractContext $context;
+
+    public function parse(AttributeNode $node)
+    {
+        $this->context->className = $node->name instanceof QualifiedName
+            ? $node->name->getResolvedName()
+            : $node->name->getText();
+
+        $this->context->autocompleting = $node->closeParen instanceof MissingToken;
+
+        return $this->context;
+    }
+
+    public function initNewContext(): ?AbstractContext
+    {
+        return new ObjectValue();
+    }
+}


### PR DESCRIPTION
This PR adds support for parsing PHP attributes. 

Example command:

```bash
./php-parser detect "<?php

namespace App\Http\Controllers;

use Illuminate\Container\Attributes\Config;

class TestController extends Controller
{
    public function __construct(
        #[Config('app.name')] protected string \$appName,
    ) {}
}
" --debug
```

Before:

```
Microsoft\PhpParser\Node\SourceFileNode <?php namespace App\Http\Controllers; use Illumina
+ Context: App\Contexts\Base
* Parsing: App\Parsers\SourceFileNodeParser

 Microsoft\PhpParser\Node\Statement\InlineHtml <?php 
 + Context: App\Contexts\Base
 * Parsing: App\Parsers\InlineHtmlParser

 Microsoft\PhpParser\Node\Statement\NamespaceDefinition namespace App\Http\Controllers;
  Microsoft\PhpParser\Node\QualifiedName App\Http\Controllers
 Microsoft\PhpParser\Node\Statement\NamespaceUseDeclaration use Illuminate\Container\Attributes\Config;
  Microsoft\PhpParser\Node\DelimitedList\NamespaceUseClauseList Illuminate\Container\Attributes\Config
   Microsoft\PhpParser\Node\NamespaceUseClause Illuminate\Container\Attributes\Config
    Microsoft\PhpParser\Node\QualifiedName Illuminate\Container\Attributes\Config
 Microsoft\PhpParser\Node\Statement\ClassDeclaration class TestController extends Controller { public f
 + Context: App\Contexts\ClassDefinition
 * Parsing: App\Parsers\ClassDeclarationParser

  Microsoft\PhpParser\Node\ClassBaseClause extends Controller
  + Context: App\Contexts\ClassDefinition
  * Parsing: App\Parsers\ClassBaseClauseParser

   Microsoft\PhpParser\Node\QualifiedName Controller
  Microsoft\PhpParser\Node\ClassMembersNode { public function __construct( #[Config('app.name'
   Microsoft\PhpParser\Node\MethodDeclaration public function __construct( #[Config('app.name')]
   + Context: App\Contexts\MethodDefinition
   * Parsing: App\Parsers\MethodDeclarationParser

    Microsoft\PhpParser\Node\DelimitedList\ParameterDeclarationList #[Config('app.name')] protected string $appName,
    + Context: App\Contexts\MethodDefinition
    * Parsing: App\Parsers\ParameterDeclarationListParser

     Microsoft\PhpParser\Node\Parameter #[Config('app.name')] protected string $appName
     + Context: App\Contexts\Parameter
     * Parsing: App\Parsers\ParameterParser

      Microsoft\PhpParser\Node\AttributeGroup #[Config('app.name')]
       Microsoft\PhpParser\Node\DelimitedList\AttributeElementList Config('app.name')
        Microsoft\PhpParser\Node\Attribute Config('app.name')
         Microsoft\PhpParser\Node\QualifiedName Config
         Microsoft\PhpParser\Node\DelimitedList\ArgumentExpressionList 'app.name'
         + Context: App\Contexts\ParameterValue
         * Parsing: App\Parsers\ArgumentExpressionListParser

          Microsoft\PhpParser\Node\Expression\ArgumentExpression 'app.name'
          + Context: App\Contexts\Argument
          * Parsing: App\Parsers\ArgumentExpressionParser

           Microsoft\PhpParser\Node\StringLiteral 'app.name'
           + Context: App\Contexts\StringValue
           * Parsing: App\Parsers\StringLiteralParser

      Microsoft\PhpParser\Node\DelimitedList\QualifiedNameList string
    Microsoft\PhpParser\Node\Statement\CompoundStatementNode {}
    + Context: App\Contexts\MethodDefinition
    * Parsing: App\Parsers\CompoundStatementNodeParser

[]
```

After:

```
Microsoft\PhpParser\Node\SourceFileNode <?php namespace App\Http\Controllers; use Illumina
+ Context: App\Contexts\Base
* Parsing: App\Parsers\SourceFileNodeParser

 Microsoft\PhpParser\Node\Statement\InlineHtml <?php 
 + Context: App\Contexts\Base
 * Parsing: App\Parsers\InlineHtmlParser

 Microsoft\PhpParser\Node\Statement\NamespaceDefinition namespace App\Http\Controllers;
  Microsoft\PhpParser\Node\QualifiedName App\Http\Controllers
 Microsoft\PhpParser\Node\Statement\NamespaceUseDeclaration use Illuminate\Container\Attributes\Config;
  Microsoft\PhpParser\Node\DelimitedList\NamespaceUseClauseList Illuminate\Container\Attributes\Config
   Microsoft\PhpParser\Node\NamespaceUseClause Illuminate\Container\Attributes\Config
    Microsoft\PhpParser\Node\QualifiedName Illuminate\Container\Attributes\Config
 Microsoft\PhpParser\Node\Statement\ClassDeclaration class TestController extends Controller { public f
 + Context: App\Contexts\ClassDefinition
 * Parsing: App\Parsers\ClassDeclarationParser

  Microsoft\PhpParser\Node\ClassBaseClause extends Controller
  + Context: App\Contexts\ClassDefinition
  * Parsing: App\Parsers\ClassBaseClauseParser

   Microsoft\PhpParser\Node\QualifiedName Controller
  Microsoft\PhpParser\Node\ClassMembersNode { public function __construct( #[Config('app.name'
   Microsoft\PhpParser\Node\MethodDeclaration public function __construct( #[Config('app.name')]
   + Context: App\Contexts\MethodDefinition
   * Parsing: App\Parsers\MethodDeclarationParser

    Microsoft\PhpParser\Node\DelimitedList\ParameterDeclarationList #[Config('app.name')] protected string $appName,
    + Context: App\Contexts\MethodDefinition
    * Parsing: App\Parsers\ParameterDeclarationListParser

     Microsoft\PhpParser\Node\Parameter #[Config('app.name')] protected string $appName
     + Context: App\Contexts\Parameter
     * Parsing: App\Parsers\ParameterParser

      Microsoft\PhpParser\Node\AttributeGroup #[Config('app.name')]
       Microsoft\PhpParser\Node\DelimitedList\AttributeElementList Config('app.name')
        Microsoft\PhpParser\Node\Attribute Config('app.name')
        + Context: App\Contexts\ObjectValue
        * Parsing: App\Parsers\AttributeParser

         Microsoft\PhpParser\Node\QualifiedName Config
         Microsoft\PhpParser\Node\DelimitedList\ArgumentExpressionList 'app.name'
         + Context: App\Contexts\ObjectValue
         * Parsing: App\Parsers\ArgumentExpressionListParser

          Microsoft\PhpParser\Node\Expression\ArgumentExpression 'app.name'
          + Context: App\Contexts\Argument
          * Parsing: App\Parsers\ArgumentExpressionParser

           Microsoft\PhpParser\Node\StringLiteral 'app.name'
           + Context: App\Contexts\StringValue
           * Parsing: App\Parsers\StringLiteralParser

      Microsoft\PhpParser\Node\DelimitedList\QualifiedNameList string
    Microsoft\PhpParser\Node\Statement\CompoundStatementNode {}
    + Context: App\Contexts\MethodDefinition
    * Parsing: App\Parsers\CompoundStatementNodeParser

[
    {
        "type": "object",
        "className": "Illuminate\\Container\\Attributes\\Config",
        "arguments": {
            "type": "arguments",
            "autocompletingIndex": 1,
            "children": [
                {
                    "type": "argument",
                    "name": null,
                    "children": [
                        {
                            "type": "string",
                            "value": "app.name",
                            "start": {
                                "line": 9,
                                "column": 17
                            },
                            "end": {
                                "line": 9,
                                "column": 25
                            }
                        }
                    ]
                }
            ]
        }
    }
]
```

